### PR TITLE
Remove redundant setup import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ see https://packaging.python.org/en/latest/distributing.html
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-from distutils.core import setup
 
 
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
I noticed this while trying to figure out what's going on in
https://github.com/pypa/packaging-problems/issues/160

(I don't think it's the cause of the problem, since setuptools
should be monkeypatching distutils anyway, but it isn't
necessary either)